### PR TITLE
Add support for validating discussion description

### DIFF
--- a/.github/workflows/test-accessibility-alt-text-bot.yml
+++ b/.github/workflows/test-accessibility-alt-text-bot.yml
@@ -6,12 +6,14 @@ on:
     types: [opened, edited]
   issue_comment:
     types: [created, edited]
+  discussion:
+    types: [created, edited]
 
 jobs:
   accessibility_alt_text_bot:
     name: Check alt text is set on issue or pull requests
     runs-on: ubuntu-latest
-    if: ${{ github.event.issue || github.event.pull_request && github.event.comment.user.login != 'accessibility-bot' }}
+    if: ${{ github.event.issue || github.event.pull_request || github.event.discussion && github.event.comment.user.login != 'accessibility-bot' }}
     steps:
       - name: Check alt text
         uses: github/accessibility-alt-text-bot@main

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Accessibility-alt-text-bot
 
-This action supports accessible content sharing on GitHub by leaving an automated reminder whenever an image is shared on a GitHub Issue or Pull request without meaningful alternative text (alt text).
+This action supports accessible content sharing on GitHub by leaving an automated reminder whenever an image is shared on a GitHub Issue, Pull request, or Discussion without meaningful alternative text (alt text).
 Alternative text helps convey the context of the image to those who use assistive technologies such as a screen reader and removes accessibility barriers.
 
 For guidance on setting alternative text, see [Alternative text for images on Primer](https://primer.style/design/guides/accessibility/alternative-text-for-images).

--- a/README.md
+++ b/README.md
@@ -15,12 +15,14 @@ on:
     types: [opened, edited]
   issue_comment:
     types: [created, edited]
+  discussion:
+    types: [created, edited]
 
 jobs:
   accessibility_alt_text_bot:
     name: Check alt text is set on issue or pull requests
     runs-on: ubuntu-latest
-    if: ${{ github.event.issue || github.event.pull_request }}
+    if: ${{ github.event.issue || github.event.pull_request || github.event.discussion }}
     steps:
       - name: Get action 'github/accessibility-alt-text-bot'
         uses: github/accessibility-alt-text-bot

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
               content=$DISCUSSION_BODY
               discussion_node_id='${{ github.event.discussion.node_id }}'
               user=${{ github.event.discussion.user.login }}
-              target=' your discussion body'
+              target=" your discussion body"
             fi
           fi
           message="Uh oh! @$user, the image you shared is missing helpful alt text. Check $target.
@@ -47,9 +47,15 @@ runs:
           
           Learn more about alt text at [Basic writing and formatting syntax: images on GitHub Docs](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#images)."
           flag="$(flagAltText "$content")"
+          
+          echo $flag
+          echo $type
+
           if [[ $flag = true ]]; then
             if [[ $type = pr_comment ]] || [[ $type = pr_description ]]; then
               gh pr comment $issue_url --body "$message"
+            elif [[ $type = issue_comment ]] || [[ $type = issue_description ]]; then
+              gh issue comment $issue_url --body "$message"
             elif [[ $type = discussion_description ]]; then
               gh api graphql -F discussionId="$discussion_node_id" -F body="$message" -f query='
                 mutation($discussionId: ID!, $body: String!) {
@@ -60,8 +66,6 @@ runs:
                   }
                 }
               '
-            else
-              gh issue comment $issue_url --body "$message"
             fi
           fi
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ runs:
               gh pr comment $issue --body "$message"
             elif [[ $is_discussion = true ]]; then
               gh api graphql -F discussionId="$discussion_node_id" -F body="$message" -f query='
-                mutation($discussionId: ID!, $body: String!, $replyToId: ID) {
+                mutation($discussionId: ID!, $body: String!) {
                   addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
                     comment {
                       id

--- a/action.yml
+++ b/action.yml
@@ -11,9 +11,9 @@ runs:
           source ${{ github.action_path }}/flag-alt-text.sh
 
           if [ ${{ github.event.comment }} ]; then
-            comment=$COMMENT
-            issue=${{ github.event.issue.html_url }}
-            comment_owner=${{ github.event.comment.user.login }}
+            content=$COMMENT
+            issue_url=${{ github.event.issue.html_url }}
+            user=${{ github.event.comment.user.login }}
             if ${{ github.event.issue.pull_request.url != '' }}; then
               type=pr_comment
             else
@@ -21,33 +21,33 @@ runs:
             fi
             target=${{ github.event.comment.html_url }}
           elif [ ${{ github.event.issue && !github.event.comment }} ]; then
-            comment=$ISSUE_BODY
-            issue=${{ github.event.issue.html_url }}
-            comment_owner=${{ github.event.issue.user.login }}
+            content=$ISSUE_BODY
+            issue_url=${{ github.event.issue.html_url }}
+            user=${{ github.event.issue.user.login }}
             type=issue_description
             target=" your issue body"
           elif [ ${{ github.event.pull_request && !github.event.comment }} ]; then
-            comment=$PR_BODY
-            issue=${{ github.event.pull_request.html_url }}
-            comment_owner=${{ github.event.pull_request.user.login }}
+            content=$PR_BODY
+            issue_url=${{ github.event.pull_request.html_url }}
+            user=${{ github.event.pull_request.user.login }}
             type=pr_description
             target=" your pull request body"
            elif [ ${{ github.event.discussion && !github.event.comment }} ]; then
-            comment=$DISCUSSION_BODY
+            content=$DISCUSSION_BODY
             discussion_node_id='${{ github.event.discussion.node_id }}'
-            comment_owner=${{ github.event.discussion.user.login }}
+            user=${{ github.event.discussion.user.login }}
             target='your discussion body'
             type=discussion_description
           fi
-          message="Uh oh! @$comment_owner, the image you shared is missing helpful alt text. Check $target.
+          message="Uh oh! @$user, the image you shared is missing helpful alt text. Check $target.
 
           Alt text is an invisible description that helps screen readers describe images to blind or low-vision users. If you are using markdown to display images, add your alt text inside the brackets of the markdown image.
           
           Learn more about alt text at [Basic writing and formatting syntax: images on GitHub Docs](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#images)."
-          flag="$(flagAltText "$comment")"
+          flag="$(flagAltText "$content")"
           if [[ $flag = true ]]; then
             if [[ $type = pr_comment ]] || [[ $type = pr_description ]]; then
-              gh pr comment $issue --body "$message"
+              gh pr comment $issue_url --body "$message"
             elif [[ $type = discussion_description ]]; then
               gh api graphql -F discussionId="$discussion_node_id" -F body="$message" -f query='
                 mutation($discussionId: ID!, $body: String!) {
@@ -59,7 +59,7 @@ runs:
                 }
               '
             else
-              gh issue comment $issue --body "$message"
+              gh issue comment $issue_url --body "$message"
             fi
           fi
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -20,24 +20,26 @@ runs:
               type=issue_comment
             fi
             target=${{ github.event.comment.html_url }}
-          elif [ ${{ github.event.issue && !github.event.comment }} ]; then
-            content=$ISSUE_BODY
-            issue_url=${{ github.event.issue.html_url }}
-            user=${{ github.event.issue.user.login }}
-            type=issue_description
-            target=" your issue body"
-          elif [ ${{ github.event.pull_request && !github.event.comment }} ]; then
-            content=$PR_BODY
-            issue_url=${{ github.event.pull_request.html_url }}
-            user=${{ github.event.pull_request.user.login }}
-            type=pr_description
-            target=" your pull request body"
-           elif [ ${{ github.event.discussion && !github.event.comment }} ]; then
-            content=$DISCUSSION_BODY
-            discussion_node_id='${{ github.event.discussion.node_id }}'
-            user=${{ github.event.discussion.user.login }}
-            target='your discussion body'
-            type=discussion_description
+          else
+            if [ ${{ github.event.issue }} ]; then
+              type=issue_description
+              content=$ISSUE_BODY
+              issue_url=${{ github.event.issue.html_url }}
+              user=${{ github.event.issue.user.login }}
+              target=" your issue body"
+            elif [ ${{ github.event.pull_request }} ]; then
+              type=pr_description
+              content=$PR_BODY
+              issue_url=${{ github.event.pull_request.html_url }}
+              user=${{ github.event.pull_request.user.login }}
+              target=" your pull request body"
+            elif [ ${{ github.event.discussion }} ]; then
+              type=discussion_description
+              content=$DISCUSSION_BODY
+              discussion_node_id='${{ github.event.discussion.node_id }}'
+              user=${{ github.event.discussion.user.login }}
+              target=' your discussion body'
+            fi
           fi
           message="Uh oh! @$user, the image you shared is missing helpful alt text. Check $target.
 

--- a/action.yml
+++ b/action.yml
@@ -14,26 +14,30 @@ runs:
             comment=$COMMENT
             issue=${{ github.event.issue.html_url }}
             comment_owner=${{ github.event.comment.user.login }}
-            is_pr=${{ github.event.issue.pull_request.url != '' }}
+            if ${{ github.event.issue.pull_request.url != '' }}; then
+              type=pr_comment
+            else
+              type=issue_comment
+            fi
             target=${{ github.event.comment.html_url }}
           elif [ ${{ github.event.issue && !github.event.comment }} ]; then
             comment=$ISSUE_BODY
             issue=${{ github.event.issue.html_url }}
             comment_owner=${{ github.event.issue.user.login }}
-            is_pr=false
+            type=issue_description
             target=" your issue body"
           elif [ ${{ github.event.pull_request && !github.event.comment }} ]; then
             comment=$PR_BODY
             issue=${{ github.event.pull_request.html_url }}
             comment_owner=${{ github.event.pull_request.user.login }}
-            is_pr=true
+            type=pr_description
             target=" your pull request body"
            elif [ ${{ github.event.discussion && !github.event.comment }} ]; then
-            comment='${{ github.event.discussion.body }}'
+            comment=$DISCUSSION_BODY
             discussion_node_id='${{ github.event.discussion.node_id }}'
             comment_owner=${{ github.event.discussion.user.login }}
-            target='your discussion description'
-            is_discussion=true
+            target='your discussion body'
+            type=discussion_description
           fi
           message="Uh oh! @$comment_owner, the image you shared is missing helpful alt text. Check $target.
 
@@ -42,9 +46,9 @@ runs:
           Learn more about alt text at [Basic writing and formatting syntax: images on GitHub Docs](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#images)."
           flag="$(flagAltText "$comment")"
           if [[ $flag = true ]]; then
-            if [[ $is_pr = true ]]; then
+            if [[ $type = pr_comment ]] || [[ $type = pr_description ]]; then
               gh pr comment $issue --body "$message"
-            elif [[ $is_discussion = true ]]; then
+            elif [[ $type = discussion_description ]]; then
               gh api graphql -F discussionId="$discussion_node_id" -F body="$message" -f query='
                 mutation($discussionId: ID!, $body: String!) {
                   addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
@@ -64,3 +68,4 @@ runs:
         COMMENT: ${{ github.event.comment.body }}
         ISSUE_BODY: ${{ github.event.issue.body }}
         PR_BODY: ${{ github.event.pull_request.body }}
+        DISCUSSION_BODY: ${{ github.event.discussion.body }}

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: Accessibility alt text bot
-description: 'This action will check a repos issue and pr comments for correct alt text usage.'
+description: 'This action will check a repos issue, discussion, or PR for correct alt text usage.'
 branding:
   icon: 'eye'
   color: 'purple'
@@ -28,6 +28,12 @@ runs:
             comment_owner=${{ github.event.pull_request.user.login }}
             is_pr=true
             target=" your pull request body"
+           elif [ ${{ github.event.discussion && !github.event.comment }} ]; then
+            comment='${{ github.event.discussion.body }}'
+            discussion_node_id='${{ github.event.discussion.node_id }}'
+            comment_owner=${{ github.event.discussion.user.login }}
+            target='your discussion description'
+            is_discussion=true
           fi
           message="Uh oh! @$comment_owner, the image you shared is missing helpful alt text. Check $target.
 
@@ -38,6 +44,16 @@ runs:
           if [[ $flag = true ]]; then
             if [[ $is_pr = true ]]; then
               gh pr comment $issue --body "$message"
+            elif [[ $is_discussion = true ]]; then
+              gh api graphql -F discussionId="$discussion_node_id" -F body="$message" -f query='
+                mutation($discussionId: ID!, $body: String!, $replyToId: ID) {
+                  addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
+                    comment {
+                      id
+                    }
+                  }
+                }
+              '
             else
               gh issue comment $issue --body "$message"
             fi


### PR DESCRIPTION
Part of: https://github.com/github/accessibility-alt-text-bot/issues/11

* Adds support for validating Discussions descriptions.
* Uses the Discussions API GraphQL to [addDiscussionComment](https://docs.github.com/en/graphql/guides/using-the-graphql-api-for-discussions#adddiscussioncomment) because adding a discussion comment is not supported via GitHub CLI core (https://github.com/cli/cli/issues/5659#issuecomment-1137585847)