### PR TITLE
Add permissions to code snippet in our README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ on:
   discussion:
     types: [created, edited]
 
+permissions:
+  issues: write
+  pull-requests: write
+  discussions: write
+  
 jobs:
   accessibility_alt_text_bot:
     name: Check alt text is set on issue or pull requests


### PR DESCRIPTION
### What

We need to ensure a repo has the correct permissions set to so the bot can post reminders.