### PR TITLE
Add support for discussion comment

### DIFF
--- a/.github/workflows/test-accessibility-alt-text-bot.yml
+++ b/.github/workflows/test-accessibility-alt-text-bot.yml
@@ -8,6 +8,8 @@ on:
     types: [created, edited]
   discussion:
     types: [created, edited]
+  discussion_comment:
+    types: [created, edited]
 
 jobs:
   accessibility_alt_text_bot:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ on:
     types: [created, edited]
   discussion:
     types: [created, edited]
+  discussion_comment:
+    types: [created, edited]
 
 permissions:
   issues: write

--- a/action.yml
+++ b/action.yml
@@ -70,7 +70,7 @@ runs:
             elif [[ $type = discussion_description ]]; then
               addDiscussionComment $discussion_node_id "$message"
             elif [[ $type = discussion_comment ]]; then
-              addDiscussionCommentAsReply $discussion_node_id $reply_to_id "$message"
+              addDiscussionComment $discussion_node_id "$message" $reply_to_id 
             fi
           fi
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,7 @@ runs:
     - name: Runs alt text check and adds comment
       run: |
           source ${{ github.action_path }}/flag-alt-text.sh
+          source ${{ github.action_path }}/queries.sh
 
           if [ ${{ github.event.comment }} ]; then
             content=$COMMENT
@@ -19,7 +20,12 @@ runs:
             elif ${{ github.event.discussion.id != '' }}; then
               type=discussion_comment
               discussion_node_id='${{ github.event.discussion.node_id }}'
-              reply_to_id='${{ github.event.comment.node_id }}'
+              comment_node_id='${{ github.event.comment.node_id }}'
+              if ${{ github.event.comment.parent_id != '' }}; then
+                reply_to_id=$(getDiscussionReplyToId $comment_node_id)
+              else
+                reply_to_id=$comment_node_id
+              fi
             else
               type=issue_comment
               issue_url=${{ github.event.issue.html_url }}
@@ -62,25 +68,9 @@ runs:
             elif [[ $type = issue_comment ]] || [[ $type = issue_description ]]; then
               gh issue comment $issue_url --body "$message"
             elif [[ $type = discussion_description ]]; then
-              gh api graphql -F discussionId="$discussion_node_id" -F body="$message" -f query='
-                mutation($discussionId: ID!, $body: String!) {
-                  addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
-                    comment {
-                      id
-                    }
-                  }
-                }
-              '
+              addDiscussionComment $discussion_node_id "$message"
             elif [[ $type = discussion_comment ]]; then
-              gh api graphql -F discussionId="$discussion_node_id" -F replyToId="$reply_to_id" -F body="$message" -f query='
-                mutation($discussionId: ID!, , $replyToId: ID, $body: String!) {
-                  addDiscussionComment(input: {discussionId: $discussionId, replyToId: $replyToId, body: $body}) {
-                    comment {
-                      id
-                    }
-                  }
-                }
-              '
+              addDiscussionCommentAsReply $discussion_node_id $reply_to_id "$message"
             fi
           fi
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -12,12 +12,17 @@ runs:
 
           if [ ${{ github.event.comment }} ]; then
             content=$COMMENT
-            issue_url=${{ github.event.issue.html_url }}
             user=${{ github.event.comment.user.login }}
             if ${{ github.event.issue.pull_request.url != '' }}; then
               type=pr_comment
+              issue_url=${{ github.event.issue.html_url }}
+            elif ${{ github.event.discussion.id != '' }}; then
+              type=discussion_comment
+              discussion_node_id='${{ github.event.discussion.node_id }}'
+              reply_to_id='${{ github.event.comment.node_id }}'
             else
               type=issue_comment
+              issue_url=${{ github.event.issue.html_url }}
             fi
             target=${{ github.event.comment.html_url }}
           else
@@ -60,6 +65,16 @@ runs:
               gh api graphql -F discussionId="$discussion_node_id" -F body="$message" -f query='
                 mutation($discussionId: ID!, $body: String!) {
                   addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
+                    comment {
+                      id
+                    }
+                  }
+                }
+              '
+            elif [[ $type = discussion_comment ]]; then
+              gh api graphql -F discussionId="$discussion_node_id" -F replyToId="$reply_to_id" -F body="$message" -f query='
+                mutation($discussionId: ID!, , $replyToId: ID, $body: String!) {
+                  addDiscussionComment(input: {discussionId: $discussionId, replyToId: $replyToId, body: $body}) {
                     comment {
                       id
                     }

--- a/queries.sh
+++ b/queries.sh
@@ -24,7 +24,7 @@ function addDiscussionComment() {
 
   if [ -n "$REPLY_TO_ID" ]; then
     gh api graphql -F discussionId="$DISCUSSION_NODE_ID" -F replyToId="$REPLY_TO_ID" -F body="$MESSAGE" -f query='
-      mutation($discussionId: ID!, , $replyToId: ID, $body: String!) {
+      mutation($discussionId: ID!, $replyToId: ID, $body: String!) {
           addDiscussionComment(input: {discussionId: $discussionId, replyToId: $replyToId, body: $body}) {
           comment {
               id

--- a/queries.sh
+++ b/queries.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Given a node_id for a Discussion Comment with a parent comment, return the parent comment's node ID.
+# Given a node_id for a discussion comment that is a reply in thread, return the parent comment's node ID.
 function getDiscussionReplyToId() {
   local NODE_ID=$1
   local REPLY_TO_DATA=$(gh api graphql -f query='
@@ -16,7 +16,7 @@ function getDiscussionReplyToId() {
   echo $REPLY_TO_DATA | jq -r '.data.node.replyTo.id'
 }
 
-# Adds a top-level discussion comment given a discussion node ID and a message.
+# Given a discussion node ID and a message, adds a top-level discussion comment.
 function addDiscussionComment() {
   local DISCUSSION_NODE_ID=$1
   local MESSAGE=$2
@@ -31,7 +31,7 @@ function addDiscussionComment() {
   '
 }
 
-# Adds a Discussion Comment as a reply to an existing discussion comment given a discussion node ID, discussion comment node ID, and a message.
+# Given a discussion node ID, discussion comment node ID, and a message, adds a discussion comment as a reply in thread.
 function addDiscussionCommentAsReply() {
   local DISCUSSION_NODE_ID=$1
   local REPLY_TO_ID=$2

--- a/queries.sh
+++ b/queries.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Given a node_id for a Discussion Comment with a parent comment, return the parent comment's node ID.
+function getDiscussionReplyToId() {
+  local NODE_ID=$1
+  local REPLY_TO_DATA=$(gh api graphql -f query='
+  query($nodeId: ID!) {
+    node(id: $nodeId) {
+      ... on DiscussionComment {
+        replyTo {
+          id
+        }
+      }
+    }
+  }' -F nodeId=$NODE_ID)
+  echo $REPLY_TO_DATA | jq -r '.data.node.replyTo.id'
+}
+
+# Adds a top-level discussion comment given a discussion node ID and a message.
+function addDiscussionComment() {
+  local DISCUSSION_NODE_ID=$1
+  local MESSAGE=$2
+  gh api graphql -F discussionId="$discussion_node_id" -F body="$message" -f query='
+    mutation($discussionId: ID!, $body: String!) {
+      addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
+        comment {
+          id
+        }
+      }
+    }
+  '
+}
+
+# Adds a Discussion Comment as a reply to an existing discussion comment given a discussion node ID, discussion comment node ID, and a message.
+function addDiscussionCommentAsReply() {
+  local DISCUSSION_NODE_ID=$1
+  local REPLY_TO_ID=$2
+  local MESSAGE=$3
+  gh api graphql -F discussionId="$DISCUSSION_NODE_ID" -F replyToId="$REPLY_TO_ID" -F body="$MESSAGE" -f query='
+    mutation($discussionId: ID!, , $replyToId: ID, $body: String!) {
+        addDiscussionComment(input: {discussionId: $discussionId, replyToId: $replyToId, body: $body}) {
+        comment {
+            id
+        }
+      }
+    }
+  '
+}

--- a/queries.sh
+++ b/queries.sh
@@ -16,33 +16,31 @@ function getDiscussionReplyToId() {
   echo $REPLY_TO_DATA | jq -r '.data.node.replyTo.id'
 }
 
-# Given a discussion node ID and a message, adds a top-level discussion comment.
+# Given a discussion node ID, a message, and an optional reply to node ID, adds a discussion comment.
 function addDiscussionComment() {
   local DISCUSSION_NODE_ID=$1
   local MESSAGE=$2
-  gh api graphql -F discussionId="$discussion_node_id" -F body="$message" -f query='
-    mutation($discussionId: ID!, $body: String!) {
-      addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
-        comment {
-          id
-        }
-      }
-    }
-  '
-}
+  local REPLY_TO_ID=$3
 
-# Given a discussion node ID, discussion comment node ID, and a message, adds a discussion comment as a reply in thread.
-function addDiscussionCommentAsReply() {
-  local DISCUSSION_NODE_ID=$1
-  local REPLY_TO_ID=$2
-  local MESSAGE=$3
-  gh api graphql -F discussionId="$DISCUSSION_NODE_ID" -F replyToId="$REPLY_TO_ID" -F body="$MESSAGE" -f query='
-    mutation($discussionId: ID!, , $replyToId: ID, $body: String!) {
-        addDiscussionComment(input: {discussionId: $discussionId, replyToId: $replyToId, body: $body}) {
-        comment {
-            id
+  if [ -n "$REPLY_TO_ID" ]; then
+    gh api graphql -F discussionId="$DISCUSSION_NODE_ID" -F replyToId="$REPLY_TO_ID" -F body="$MESSAGE" -f query='
+      mutation($discussionId: ID!, , $replyToId: ID, $body: String!) {
+          addDiscussionComment(input: {discussionId: $discussionId, replyToId: $replyToId, body: $body}) {
+          comment {
+              id
+          }
         }
       }
-    }
-  '
+    '
+  else
+    gh api graphql -F discussionId="$discussion_node_id" -F body="$message" -f query='
+      mutation($discussionId: ID!, $body: String!) {
+        addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
+          comment {
+            id
+          }
+        }
+      }
+    '
+  fi
 }


### PR DESCRIPTION
Fixes: https://github.com/github/accessibility-alt-text-bot/issues/11

This PR adds support for discussion comments. Because the `action.yml` is getting big, I introduced a `queries.sh` file to move the GraphQL calls into, including the mutation call we introduced in https://github.com/github/accessibility-alt-text-bot/pull/14. 

We are using the [`addDiscussionComment`](https://docs.github.com/en/graphql/guides/using-the-graphql-api-for-discussions#adddiscussioncomment) and setting the `replyToId` to post a comment as a reply in a thread.

When replying to a top-level discussion comment, we're able to use `github.event.comment.node_id` as the `replyToId` to post a reply successfully.

However, I ran into issues making the same call when replying to a discussion comment inside of a thread. I kept running into the error:

```bash
gh: Parent comment is already in a thread, cannot reply to it
```

I discovered that `replyToId` has to be a top-level/parent comment node id. Since the `github.event.comment.node_id` only contains the node ID of the comment we're replying to, we must make a GraphQL query to get the parent comment node ID. We do that in the function `getDiscussionReplyToId`.