### PR TITLE
Flag images without alt text

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,8 +59,8 @@ runs:
           Learn more about alt text at [Basic writing and formatting syntax: images on GitHub Docs](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#images)."
           flag="$(flagAltText "$content")"
           
-          echo $flag
-          echo $type
+          echo "Detected bad alt text: ${flag}"
+          echo "Event type: $type"
 
           if [[ $flag = true ]]; then
             if [[ $type = pr_comment ]] || [[ $type = pr_description ]]; then

--- a/flag-alt-text.sh
+++ b/flag-alt-text.sh
@@ -6,10 +6,9 @@ flagAltText() {
     markdownImageRegex="^.*!\[(i|I)mage\].*$"
     semanticImageRegex="^.*<img.*alt=\"(i|I)mage\".*$"
     emptySemanticRegex="^.*<img.*alt=(\"|')(\"|').*$"
-    withoutAltRegex="^.*<img((?!alt=).)>.*$"
     emptyMarkdownRegex="^.*!\[\].*$"
 
-    if [[ $1 =~ $withoutAltRegex ]] || [[ $1 =~ $semanticMacOsScreenshotRegex ]] || [[ $1 =~ $markdownMacOsScreenshotRegex ]] || [[ $1 =~ $semanticImageRegex ]] || [[ $1 =~ $markdownImageRegex ]]  || [[ $1 =~ $emptySemanticRegex ]] || [[ $1 =~ $emptyMarkdownRegex ]]; then
+    if [[ $1 =~ $semanticMacOsScreenshotRegex ]] || [[ $1 =~ $markdownMacOsScreenshotRegex ]] || [[ $1 =~ $semanticImageRegex ]] || [[ $1 =~ $markdownImageRegex ]] || [[ $1 =~ $emptySemanticRegex ]] || [[ $1 =~ $emptyMarkdownRegex ]]; then
         echo true
     else
         echo false

--- a/flag-alt-text.sh
+++ b/flag-alt-text.sh
@@ -4,11 +4,13 @@ flagAltText() {
     markdownMacOsScreenshotRegex="^.*!\[(Clean|Screen) ?[S|s]hot [0-9][0-9][0-9][0-9]-[0-1][0-9]-[0-9][0-9].*\].*$"
     semanticMacOsScreenshotRegex="^.*<img.*(Clean|Screen) ?[S|s]hot [0-9][0-9][0-9][0-9]-[0-1][0-9]-[0-9][0-9].*$"
     markdownImageRegex="^.*!\[(i|I)mage\].*$"
-    semanticImageRegex="^.*<img.*alt=\"(i|I)mage\".*$"
+    semanticImageRegexStartingWithImage="^.*<img.*alt=\"(i|I)mage\".*$"
     emptySemanticRegex="^.*<img.*alt=(\"|')(\"|').*$"
     emptyMarkdownRegex="^.*!\[\].*$"
+    semanticImageRegex="^.*<img.*$"
+    semanticImageWithAltRegex="^.*<img.*alt=.*$"
 
-    if [[ $1 =~ $semanticMacOsScreenshotRegex ]] || [[ $1 =~ $markdownMacOsScreenshotRegex ]] || [[ $1 =~ $semanticImageRegex ]] || [[ $1 =~ $markdownImageRegex ]] || [[ $1 =~ $emptySemanticRegex ]] || [[ $1 =~ $emptyMarkdownRegex ]]; then
+    if [[ ($1 =~ $semanticImageRegex) && ! ($1 =~ $semanticImageWithAltRegex) ]] || [[ $1 =~ $semanticMacOsScreenshotRegex ]] || [[ $1 =~ $markdownMacOsScreenshotRegex ]] || [[ $1 =~ $semanticImageRegexStartingWithImage ]] || [[ $1 =~ $markdownImageRegex ]] || [[ $1 =~ $emptySemanticRegex ]] || [[ $1 =~ $emptyMarkdownRegex ]]; then
         echo true
     else
         echo false

--- a/flag-alt-text.sh
+++ b/flag-alt-text.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 
 flagAltText() {
-  markdownMacOsScreenshotRegex="^.*!\[(Clean|Screen) ?[S|s]hot [0-9][0-9][0-9][0-9]-[0-1][0-9]-[0-9][0-9].*\].*$"
-  semanticMacOsScreenshotRegex="^.*<img.*(Clean|Screen) ?[S|s]hot [0-9][0-9][0-9][0-9]-[0-1][0-9]-[0-9][0-9].*$"
-  markdownImageRegex="^.*!\[(i|I)mage\].*$"
-  semanticImageRegex="^.*<img.*alt=\"(i|I)mage\".*$"
-  if  [[ $1 =~ $semanticMacOsScreenshotRegex ]] || [[ $1 =~ $markdownMacOsScreenshotRegex ]] || [[ $1 =~ $semanticImageRegex ]] || [[ $1 =~ $markdownImageRegex ]]; then
-    echo true
-  else
-    echo false
-  fi
+    markdownMacOsScreenshotRegex="^.*!\[(Clean|Screen) ?[S|s]hot [0-9][0-9][0-9][0-9]-[0-1][0-9]-[0-9][0-9].*\].*$"
+    semanticMacOsScreenshotRegex="^.*<img.*(Clean|Screen) ?[S|s]hot [0-9][0-9][0-9][0-9]-[0-1][0-9]-[0-9][0-9].*$"
+    markdownImageRegex="^.*!\[(i|I)mage\].*$"
+    semanticImageRegex="^.*<img.*alt=\"(i|I)mage\".*$"
+    emptySemanticRegex="^.*<img.*alt=(\"|')(\"|').*$"
+    withoutAltRegex="^.*<img((?!alt=).)>.*$"
+    emptyMarkdownRegex="^.*!\[\].*$"
+
+    if [[ $1 =~ $withoutAltRegex ]] || [[ $1 =~ $semanticMacOsScreenshotRegex ]] || [[ $1 =~ $markdownMacOsScreenshotRegex ]] || [[ $1 =~ $semanticImageRegex ]] || [[ $1 =~ $markdownImageRegex ]]  || [[ $1 =~ $emptySemanticRegex ]] || [[ $1 =~ $emptyMarkdownRegex ]]; then
+        echo true
+    else
+        echo false
+    fi
 }

--- a/test-flag-alt-text.sh
+++ b/test-flag-alt-text.sh
@@ -21,10 +21,11 @@ declare -a should_be_true=(
     # html
     '<img alt="image" src="cat.png">'
     '<img alt="" src="cat.png">'
-    "<img alt='' src="cat.png">"
-    '<img src="cat.png">'
-    '<img alt src="cat.png">'
-    '<img src="cat.png" width="10px">'
+    "<img alt='' src='cat.png'>"
+    # TODO: add flag for these cases
+    # "<img src="cat.png">"
+    # '<img alt src="cat.png">'
+    # '<img src="cat.png" width="10px">'
     '<img alt="Screen shot 2020-01-01 at 12.00.00.png" src="cat.png">'
     '<img alt="Screen Shot 2020-01-01 at 12.00.00.png" src="cat.png">'
     '<img alt="Screenshot 2020-01-01 at 12.00.00.png" src="cat.png">'
@@ -44,23 +45,20 @@ declare -a should_be_false=(
 )
 
 echo "******Expecting true:*******"
-for i in "${should_be_true[@]}"
-do
+for i in "${should_be_true[@]}"; do
     echo "Testing: $i"
     assert_true "$(flagAltText "$i")" "$i must be true"
-    if [ $? == 1 ]; then
-        exit 1
-    fi
-    
+    # if [ $? == 1 ]; then
+    #     exit 1
+    # fi
+
 done
 
 echo "******Expecting false:*******"
-for i in "${should_be_false[@]}"
-do
+for i in "${should_be_false[@]}"; do
     echo "Testing: $i"
     assert_false "$(flagAltText "$i")" "$i must be false"
-    if [ $? == 1 ]; then
-        exit 1
-    fi
+    # if [ $? == 1 ]; then
+    #     exit 1
+    # fi
 done
-

--- a/test-flag-alt-text.sh
+++ b/test-flag-alt-text.sh
@@ -6,47 +6,54 @@ source assert.sh
 # true
 
 declare -a should_be_true=(
-  # markdown
-  '![Cleanshot 2020-01-01 at 12.00.00.png]' 
-  '![Clean shot 2020-12-01 @12x]'
-  "![Clean shot 2020-12-01 @12x]"
-  "![Screen Shot 2020-01-01 at 12.00.00.png]"
-  "![Screenshot 2020-01-01 at 12.00.00.png]"
-  "![image]"
-  "![Image]"
-  "Check this: ![Image]"
-  "My awesome ![image]"
-  'Check this out: <img alt="image" src="cat.png">'
-  # html
-  '<img alt="image" src="cat.png">'
-  '<img alt="Screen shot 2020-01-01 at 12.00.00.png" src="cat.png">'
-  '<img alt="Screen Shot 2020-01-01 at 12.00.00.png" src="cat.png">'
-  '<img alt="Screenshot 2020-01-01 at 12.00.00.png" src="cat.png">'
-  '<img alt="CleanShot 2020-01-01 @12x" src="cat.png">'
+    # markdown
+    '![Cleanshot 2020-01-01 at 12.00.00.png]'
+    '![Clean shot 2020-12-01 @12x]'
+    "![Clean shot 2020-12-01 @12x]"
+    "![Screen Shot 2020-01-01 at 12.00.00.png]"
+    "![Screenshot 2020-01-01 at 12.00.00.png]"
+    "![image]"
+    "![Image]"
+    "![]"
+    "Check this: ![Image]"
+    "My awesome ![image]"
+    'Check this out: <img alt="image" src="cat.png">'
+    # html
+    '<img alt="image" src="cat.png">'
+    '<img alt="" src="cat.png">'
+    "<img alt='' src="cat.png">"
+    '<img src="cat.png">'
+    '<img alt src="cat.png">'
+    '<img src="cat.png" width="10px">'
+    '<img alt="Screen shot 2020-01-01 at 12.00.00.png" src="cat.png">'
+    '<img alt="Screen Shot 2020-01-01 at 12.00.00.png" src="cat.png">'
+    '<img alt="Screenshot 2020-01-01 at 12.00.00.png" src="cat.png">'
+    '<img alt="CleanShot 2020-01-01 @12x" src="cat.png">'
 )
 
 declare -a should_be_false=(
-  # markdown
-  "![Screenshot of the new GitHub home page]" 
-  "![Screen shot of Submit button with updated color contrast.]"
-  "![Image of a cat]"
-  # html
-  '<img alt="Mona Lisa, the Octocat" src="cat.png">'
-  '<img alt="Screenshot of the new danger button with a dark red shade" src="test.png">'
-  '<img alt="Clean shot of the scenery" src="test.png">'
+    # markdown
+    "![Screenshot of the new GitHub home page]"
+    "![Screen shot of Submit button with updated color contrast.]"
+    "![Image of a cat]"
+    # html
+    '<img src="cat.png" alt="Mona Lisa, the Octocat" >'
+    '<img alt="Mona Lisa, the Octocat" src="cat.png">'
+    '<img alt="Screenshot of the new danger button with a dark red shade" src="test.png">'
+    '<img alt="Clean shot of the scenery" src="test.png">'
 )
 
 echo "******Expecting true:*******"
 for i in "${should_be_true[@]}"
 do
-  echo "Testing: $i"
-  assert_true "$(flagAltText "$i")" "$i must be true"
+    echo "Testing: $i"
+    assert_true "$(flagAltText "$i")" "$i must be true"
 done
 
 echo "******Expecting false:*******"
 for i in "${should_be_false[@]}"
 do
-  echo "Testing: $i"
-  assert_false "$(flagAltText "$i")" "$i must be false"
+    echo "Testing: $i"
+    assert_false "$(flagAltText "$i")" "$i must be false"
 done
 

--- a/test-flag-alt-text.sh
+++ b/test-flag-alt-text.sh
@@ -48,17 +48,16 @@ echo "******Expecting true:*******"
 for i in "${should_be_true[@]}"; do
     echo "Testing: $i"
     assert_true "$(flagAltText "$i")" "$i must be true"
-    # if [ $? == 1 ]; then
-    #     exit 1
-    # fi
-
+    if [ $? == 1 ]; then
+        exit 1
+    fi
 done
 
 echo "******Expecting false:*******"
 for i in "${should_be_false[@]}"; do
     echo "Testing: $i"
     assert_false "$(flagAltText "$i")" "$i must be false"
-    # if [ $? == 1 ]; then
-    #     exit 1
-    # fi
+    if [ $? == 1 ]; then
+        exit 1
+    fi
 done

--- a/test-flag-alt-text.sh
+++ b/test-flag-alt-text.sh
@@ -48,6 +48,10 @@ for i in "${should_be_true[@]}"
 do
     echo "Testing: $i"
     assert_true "$(flagAltText "$i")" "$i must be true"
+    if [ $? == 1 ]; then
+        exit 1
+    fi
+    
 done
 
 echo "******Expecting false:*******"
@@ -55,5 +59,8 @@ for i in "${should_be_false[@]}"
 do
     echo "Testing: $i"
     assert_false "$(flagAltText "$i")" "$i must be false"
+    if [ $? == 1 ]; then
+        exit 1
+    fi
 done
 

--- a/test-flag-alt-text.sh
+++ b/test-flag-alt-text.sh
@@ -22,10 +22,9 @@ declare -a should_be_true=(
     '<img alt="image" src="cat.png">'
     '<img alt="" src="cat.png">'
     "<img alt='' src='cat.png'>"
-    # TODO: add flag for these cases
-    # "<img src="cat.png">"
-    # '<img alt src="cat.png">'
-    # '<img src="cat.png" width="10px">'
+    "<img src="cat.png">"
+    '<img alt src="cat.png">'
+    '<img src="cat.png" width="10px">'
     '<img alt="Screen shot 2020-01-01 at 12.00.00.png" src="cat.png">'
     '<img alt="Screen Shot 2020-01-01 at 12.00.00.png" src="cat.png">'
     '<img alt="Screenshot 2020-01-01 at 12.00.00.png" src="cat.png">'


### PR DESCRIPTION
resolves #23 

### What

I am adding a couple new flags:
- Flags when an image tag contians `<img alt='' ...`
- Flags when a markdown image is empty `![]`
- Flags when an images does not contain alt text `<img />`

Our CI was not actually failing when a test failed. I fixed this by adding `exit 1` when a unit test failed. 

