### PR TITLE
Use GitHub alerts syntax, and use tip instead of note

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This action flags when the alt text has not been updated from the default:
 
 <img width="758" alt="Screenshot of an automated actions comment on a GitHub issue that says, 'Uh oh! @monalisa, the image you shared is missing helpful alt text...' and contains instructions for setting alt text" src="https://github.com/github/accessibility-alt-text-bot/assets/16447748/c61cc9c6-f8c8-4bfb-becb-a155c2c9711d">
 
-> **Note**
+> [!TIP]
 > Normally, setting `alt=""` marks images as decorative. But GitHub renders all images as a link. To avoid rendering links with no names, we recommend always setting alt text on images in GitHub.
 
 ## How to add this action to your repo


### PR DESCRIPTION
## Changes:

- Use GitHub alerts syntax [^1]
- Use `TIP` alert instead of note

## Context:

The current note is a bit hidden, because it uses the quote-styling, which de-emphasizes the content. Having a proper alert with the tip styling looks better.

[^1]: [GitHub Docs, alerts syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts)