### PR TITLE
Update readme to ignore markdown generated by bots

### DIFF
--- a/.github/workflows/test-accessibility-alt-text-bot.yml
+++ b/.github/workflows/test-accessibility-alt-text-bot.yml
@@ -15,7 +15,7 @@ jobs:
   accessibility_alt_text_bot:
     name: Check alt text is set on issue or pull requests
     runs-on: ubuntu-latest
-    if: ${{ github.event.issue || github.event.pull_request || github.event.discussion && github.event.comment.user.login != 'accessibility-bot' }}
+    if: ${{ github.event.issue || github.event.pull_request || github.event.discussion && github.event.comment.user.login != 'accessibility-bot' }} && ${{ !endsWith(github.actor, '[bot]') }}
     steps:
       - name: Check alt text
         uses: github/accessibility-alt-text-bot@main

--- a/.github/workflows/test-accessibility-alt-text-bot.yml
+++ b/.github/workflows/test-accessibility-alt-text-bot.yml
@@ -15,7 +15,7 @@ jobs:
   accessibility_alt_text_bot:
     name: Check alt text is set on issue or pull requests
     runs-on: ubuntu-latest
-    if: ${{ github.event.issue || github.event.pull_request || github.event.discussion && github.event.comment.user.login != 'accessibility-bot' }} && ${{ !endsWith(github.actor, '[bot]') }}
+    if: ${{ !endsWith(github.actor, '[bot]') }}
     steps:
       - name: Check alt text
         uses: github/accessibility-alt-text-bot@main

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ permissions:
 jobs:
   accessibility_alt_text_bot:
     name: Check alt text is set on issue or pull requests
+    if: ${{ !endsWith(github.actor, '[bot]') }}
     runs-on: ubuntu-latest
     steps:
       - name: Get action 'github/accessibility-alt-text-bot'


### PR DESCRIPTION
Closes https://github.com/github/accessibility-alt-text-bot/issues/45

### What

As suggested in https://github.com/github/accessibility-alt-text-bot/issues/45, I updated our documentation to suggest that the alt-text-bot ignores messages generated by bots. This will help reduce the number of unnecessary workflow runs caused by bots updating comments.